### PR TITLE
Calculate RHOC balances by netting past transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Specify options by setting shell variables:
 
 ```bash
 BLOCK=<block height>
-ETH_WS=<websockets provider>
+ETH_API_URL=<http provider>
 ```
 
-Eth provider defaults to local node (`ws://localhost:8546`).
+Eth provider defaults to local node (`http://localhost:8545`).
 
 ```bash
 $ BLOCK=7588056 node balances >wallets_7588056.txt

--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ $ BLOCK=7588056 node balances >wallets_7588056.txt
 ### Improvements
 
 * Timestamp balances.csv output so that it can be included in version control.
+
+### Note from new maintainer
+
+This tool was originally written by @desaperados
+(https://github.com/desaperados/rrc). It used to call `balanceOf()`
+contract method to get address balances. This however doesn't work
+with older blocks (as right bound) when querying a state pruning node
+like Parity. This rewrite calculates balances by netting transfers.

--- a/balances.js
+++ b/balances.js
@@ -54,7 +54,7 @@ async function* getTransferEvents(_fromBlock, _toBlock) {
 }
 
 async function* getNetBalances(xferEventsIter) {
-	let balances = {}
+	let balances = new Map()
 
 	for await (ev of xferEventsIter) {
 		let xfer = ev.returnValues

--- a/balances.js
+++ b/balances.js
@@ -47,9 +47,6 @@ async function* getBalances() {
 }
 
 (async () => {
-	let timerId = setInterval(async () => {
-		await web3.eth.isSyncing()
-	}, 1000)
 	try {
 		for await ([key, bal, c] of getBalances()) {
 			process.stdout.write(key + ',' + bal + ',' + c + '\n')
@@ -57,7 +54,6 @@ async function* getBalances() {
 	} catch (e) {
 		console.error(e)
 	} finally {
-		clearInterval(timerId)
 		process.exit()
 	}
 })();

--- a/balances.js
+++ b/balances.js
@@ -18,14 +18,18 @@
 
 const Web3 = require('web3');
 
+const deployAddr       = '0x168296bb09e24a88805cb9c33356536b980d3fc5'
+const deployBlock      = 3383352
+const tokenMintAddr    = '0xe17C20292b2F1b0Ff887Dc32A73C259Fae25f03B'
+const tokenSupply      = 100000000000000000
+
 const apiUrl    = process.env.ETH_API_URL || process.env.ETH_WS || 'http://localhost:8545'
-const fromBlock = 3383352;
 const toBlock	= process.env.BLOCK || 'latest';
 const dumpXfers = !!process.env.DUMP_XFERS
 const chunkSize = 500
 
 const web3 = new Web3(apiUrl)
-const rhoc = new web3.eth.Contract(require('./abi.json'), "0x168296bb09e24a88805cb9c33356536b980d3fc5");
+const rhoc = new web3.eth.Contract(require('./abi.json'), deployAddr);
 
 async function* getTransferEvents(_fromBlock, _toBlock) {
 
@@ -55,6 +59,7 @@ async function* getTransferEvents(_fromBlock, _toBlock) {
 
 async function* getNetBalances(xferEventsIter) {
 	let balances = new Map()
+	balances[tokenMintAddr] = BigInt(tokenSupply)
 
 	for await (ev of xferEventsIter) {
 		let xfer = ev.returnValues
@@ -78,7 +83,7 @@ async function* getNetBalances(xferEventsIter) {
 (async () => {
 	let exitCode = 0
 	try {
-		let xferEventsIter = getTransferEvents(fromBlock, toBlock)
+		let xferEventsIter = getTransferEvents(deployBlock, toBlock)
 		if (dumpXfers) {
 			for await (xferEvent of xferEventsIter) {
 				console.log(JSON.stringify(xferEvent))

--- a/balances.js
+++ b/balances.js
@@ -26,7 +26,7 @@ const tokenSupply      = 100000000000000000
 const apiUrl    = process.env.ETH_API_URL || process.env.ETH_WS || 'http://localhost:8545'
 const toBlock	= process.env.BLOCK || 'latest';
 const dumpXfers = !!process.env.DUMP_XFERS
-const chunkSize = 500
+const chunkSize = process.env.CHUNK_SIZE || 1000000
 
 const web3 = new Web3(apiUrl)
 const rhoc = new web3.eth.Contract(require('./abi.json'), deployAddr);

--- a/balances.js
+++ b/balances.js
@@ -18,7 +18,7 @@
 
 const Web3 = require('web3');
 
-const apiUrl    = process.env.ETH_WS || 'http://localhost:8545'
+const apiUrl    = process.env.ETH_API_URL || process.env.ETH_WS || 'http://localhost:8545'
 const fromBlock = 3383352;
 const toBlock	= process.env.BLOCK || 7588056;
 

--- a/balances.js
+++ b/balances.js
@@ -21,6 +21,7 @@ const Web3 = require('web3');
 const apiUrl    = process.env.ETH_API_URL || process.env.ETH_WS || 'http://localhost:8545'
 const fromBlock = 3383352;
 const toBlock	= process.env.BLOCK || 'latest';
+const dumpXfers = !!process.env.DUMP_XFERS
 const chunkSize = 500
 
 const web3 = new Web3(apiUrl)
@@ -75,9 +76,15 @@ async function* getNetBalances(xferEventsIter) {
 (async () => {
 	let exitCode = 0
 	try {
-		let xferEvents = getTransferEvents(fromBlock, toBlock)
-		for await ([addr, bal, c] of getNetBalances(xferEvents)) {
-			process.stdout.write(addr + ',' + bal + ',' + c + '\n')
+		let xferEventsIter = getTransferEvents(fromBlock, toBlock)
+		if (dumpXfers) {
+			for await (xferEvent of xferEventsIter) {
+				console.log(JSON.stringify(xferEvent))
+			}
+		} else {
+			for await ([addr, bal, c] of getNetBalances(xferEventsIter)) {
+				process.stdout.write(addr + ',' + bal + ',' + c + '\n')
+			}
 		}
 	} catch (e) {
 		console.error(e)

--- a/balances.js
+++ b/balances.js
@@ -47,13 +47,15 @@ async function* getBalances() {
 }
 
 (async () => {
+	let exitCode = 0
 	try {
 		for await ([key, bal, c] of getBalances()) {
 			process.stdout.write(key + ',' + bal + ',' + c + '\n')
 		}
 	} catch (e) {
 		console.error(e)
+		exitCode = 1
 	} finally {
-		process.exit()
+		process.exit(exitCode)
 	}
 })();

--- a/balances.js
+++ b/balances.js
@@ -18,11 +18,12 @@
 
 const Web3 = require('web3');
 
-const web3 = new Web3(process.env.ETH_WS || 'ws://localhost:8546')
-const rhoc = new web3.eth.Contract(require('./abi.json'), "0x168296bb09e24a88805cb9c33356536b980d3fc5");
-
+const apiUrl    = process.env.ETH_WS || 'http://localhost:8545'
 const fromBlock = 3383352;
 const toBlock	= process.env.BLOCK || 7588056;
+
+const web3 = new Web3(apiUrl)
+const rhoc = new web3.eth.Contract(require('./abi.json'), "0x168296bb09e24a88805cb9c33356536b980d3fc5");
 
 async function* getKeys() {
 	let keys = new Set()

--- a/balances.js
+++ b/balances.js
@@ -42,8 +42,10 @@ async function* getKeys() {
 async function* getBalances() {
 	for await (key of getKeys()) {
 		let bal = await rhoc.methods.balanceOf(key).call({}, toBlock)
-		let c = await web3.eth.getCode(key).then(code => code == '0x' ? 0 : 1)
-		yield [key, bal, c]
+		if (bal > 0) {
+			let c = await web3.eth.getCode(key).then(code => code == '0x' ? 0 : 1)
+			yield [key, bal, c]
+		}
 	}
 }
 

--- a/balances.js
+++ b/balances.js
@@ -52,10 +52,10 @@ async function* getTransferEvents(_fromBlock, _toBlock) {
 		yield* getTransferEventsInRange(fromBlock, _toBlock)
 }
 
-async function* getBalances(fromBlock, toBlock) {
+async function* getNetBalances(xferEventsIter) {
 	let balances = {}
 
-	for await (ev of getTransferEvents(fromBlock, toBlock)) {
+	for await (ev of xferEventsIter) {
 		let xfer    = ev.returnValues
 		let amount  = BigInt(xfer.value)
 		let fromBal = balances[xfer.from] || 0n // BigInt(0)
@@ -75,7 +75,8 @@ async function* getBalances(fromBlock, toBlock) {
 (async () => {
 	let exitCode = 0
 	try {
-		for await ([addr, bal, c] of getBalances(fromBlock, toBlock)) {
+		let xferEvents = getTransferEvents(fromBlock, toBlock)
+		for await ([addr, bal, c] of getNetBalances(xferEvents)) {
 			process.stdout.write(addr + ',' + bal + ',' + c + '\n')
 		}
 	} catch (e) {

--- a/balances.js
+++ b/balances.js
@@ -20,7 +20,7 @@ const Web3 = require('web3');
 
 const apiUrl    = process.env.ETH_API_URL || process.env.ETH_WS || 'http://localhost:8545'
 const fromBlock = 3383352;
-const toBlock	= process.env.BLOCK || 7588056;
+const toBlock	= process.env.BLOCK || 'latest';
 const chunkSize = 500
 
 const web3 = new Web3(apiUrl)

--- a/balances.js
+++ b/balances.js
@@ -57,7 +57,9 @@ async function* getNetBalances(xferEventsIter) {
 	let balances = {}
 
 	for await (ev of xferEventsIter) {
-		let xfer    = ev.returnValues
+		let xfer = ev.returnValues
+		if (xfer.from === xfer.to)
+			continue
 		let amount  = BigInt(xfer.value)
 		let fromBal = balances[xfer.from] || 0n // BigInt(0)
 		let toBal   = balances[xfer.to]   || 0n

--- a/balances.js
+++ b/balances.js
@@ -31,7 +31,7 @@ const chunkSize = 500
 const web3 = new Web3(apiUrl)
 const rhoc = new web3.eth.Contract(require('./abi.json'), deployAddr);
 
-async function* getTransferEvents(_fromBlock, _toBlock) {
+async function* getTransferEvents(_toBlock) {
 
 	async function* getTransferEventsInRange(fromBlock, toBlock) {
 		for (ev of await rhoc.getPastEvents('Transfer', { fromBlock, toBlock } )) {
@@ -43,12 +43,12 @@ async function* getTransferEvents(_fromBlock, _toBlock) {
 		}
 	}
 
-	let count = _toBlock - _fromBlock + 1
+	let count = _toBlock - deployBlock + 1
 
 	let iters = Math.floor(count / chunkSize)
 	for (let i = 0; i < iters; i++) {
-		let fromBlock = _fromBlock + i * chunkSize
-		let toBlock   = _fromBlock + (i + 1) * chunkSize - 1
+		let fromBlock = deployBlock + i * chunkSize
+		let toBlock   = deployBlock + (i + 1) * chunkSize - 1
 		yield* getTransferEventsInRange(fromBlock, toBlock)
 	}
 
@@ -83,7 +83,7 @@ async function* getNetBalances(xferEventsIter) {
 (async () => {
 	let exitCode = 0
 	try {
-		let xferEventsIter = getTransferEvents(deployBlock, toBlock)
+		let xferEventsIter = getTransferEvents(toBlock)
 		if (dumpXfers) {
 			for await (xferEvent of xferEventsIter) {
 				console.log(JSON.stringify(xferEvent))

--- a/balances.js
+++ b/balances.js
@@ -39,6 +39,9 @@ async function* getTransferEvents(_toBlock) {
 				console.warning('Got pending transfer event, skipping...')
 				continue
 			}
+			if (ev.removed) {
+				throw 'Got unexpected removed transfer event: ' + JSON.stringify(ev)
+			}
 			yield ev
 		}
 	}


### PR DESCRIPTION
As per new entry in README:
```
This tool was originally written by @desaperados
(https://github.com/desaperados/rrc). It used to call `balanceOf()`
contract method to get address balances. This however doesn't work
with older blocks (as right bound) when querying a state pruning node
like Parity. This rewrite calculates balances by netting transfers.
```