### PR TITLE
Update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -250,7 +250,7 @@ eth-lib@0.2.8:
   integrity sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==
   dependencies:
     bn.js "^4.11.6"
-    elliptic "^6.4.0"
+    elliptic "^6.5.3"
     xhr-request-promise "^0.1.2"
 
 ethereum-common@^0.0.18:
@@ -287,7 +287,7 @@ ethers@^4.0.27:
     "@types/node" "^10.3.2"
     aes-js "3.0.0"
     bn.js "^4.4.0"
-    elliptic "6.3.3"
+    elliptic "6.5.3"
     hash.js "1.1.3"
     js-sha3 "0.5.7"
     scrypt-js "2.0.4"
@@ -674,7 +674,7 @@ secp256k1@^3.0.1:
     bn.js "^4.11.8"
     create-hash "^1.2.0"
     drbg.js "^1.0.1"
-    elliptic "^6.4.1"
+    elliptic "^6.5.3"
     nan "^2.14.0"
     safe-buffer "^5.1.2"
 


### PR DESCRIPTION
Updated elliptic version to 6.5.3 in three different places, to resolve the dependabot alert